### PR TITLE
Optimize Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,52 @@
-FROM rust:1.53 as builder
+###########################
+### STRIP-VERSION STAGE ###
+###########################
+FROM rust:1.53 as strip-version
 
-WORKDIR /usr/src/
-
-RUN cargo new --bin digit-web
-
+# Strip version from Cargo.*
+# This avoids cache invalidations (ergo rebuilding all deps) when bumping the version number
+RUN cargo install strip_cargo_version
 WORKDIR /usr/src/digit-web
 COPY Cargo.toml Cargo.lock ./
-RUN cargo install --path .
-COPY src ./src/
-COPY Rocket.toml ./Rocket.toml
-RUN cargo build --release
+RUN strip_cargo_version
 
-FROM debian:buster-slim
-WORKDIR /app/digit.chalmers.it
+###################
+### BUILD STAGE ###
+###################
+FROM rust:1.53 as build
+WORKDIR /usr/src/
+
+# Install build-target for static linking
+RUN rustup target add x86_64-unknown-linux-musl
+
+# Create a dummy binary for pre-compiling dependencies (for caching)
+RUN cargo new --bin digit-web
+WORKDIR /usr/src/digit-web
+COPY --from=strip-version /usr/src/digit-web/Cargo.* ./
+RUN cargo build --release --target x86_64-unknown-linux-musl
+
+# Copy the actual source files
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+
+# Compile the final binary
+RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN strip target/x86_64-unknown-linux-musl/release/digit2021
+
+########################
+### PRODUCTION STAGE ###
+########################
+FROM scratch
+WORKDIR /
+
+EXPOSE 9999
+ENV ROCKET_PORT="9999"
+ENV ROCKET_ADDRESS="0.0.0.0"
+ENV ROCKET_IDENT="UwU? notices client OwO"
+
 COPY data ./data/
 COPY templates ./templates/
 COPY static/ ./static/
-COPY Rocket.toml ./Rocket.toml
-COPY --from=builder /usr/src/digit-web/target/release/digit2021 ./app
-
+COPY --from=build /usr/src/digit-web/target/x86_64-unknown-linux-musl/release/digit2021 ./app
 
 CMD ["./app"]


### PR DESCRIPTION
### Improvements:
- Avoid recompiling dependencies when changing version number
  This speeds up image creation significantly if deps haven't changed
- Optimize final image size (111MB -> 37MB)
  - Compile static binary
  - `strip` binary
  - Use `FROM scratch` (zero overhead base image)