### PR TITLE
Main page returns ANSI text when fetched by curl

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ impl<'r> FromRequest<'r> for TerminalOutput {
         }
 
         if let Some(media_type) = request.headers().get_one("Accept") {
-            if media_type.contains("text/plain") {
+            if media_type.contains("text/plain") && !media_type.contains("text/html") {
                 return Outcome::Success(TerminalOutput(true));
             }
         }

--- a/templates/index.ansi.html.tera
+++ b/templates/index.ansi.html.tera
@@ -1,0 +1,37 @@
+[38;2;9;205;218m                                        01100
+                                     100011010010
+                                    110011101001001
+                              0101 01000110010001101
+                            001011001110100100101010
+                           1000110010         001101
+                          001011001          110100100
+                       1010101000         11001000110100
+                      10110011101             00100101010
+                     10001100100               01101001011
+                     00111010010               01010101000
+                     110010001101              00101100111
+                      010010010101           010001100100
+                        01101001011001110100100101010100
+                          011001000110100101100111010
+
+                             0              100101010100
+                         01100   1   00011  010   010
+                         1   1   0  0    1  110   100
+                         1   0   0  1    0  101   010
+                         00 11   0   01000  110   100
+                                         1
+                                     011
+
+                 digit@chalmers.it | #digIT on irc.chalmers.it
+            Facebook/digitchalmers | Twitter/digITcth | GitHub/cthit
+
+[7m About us [27m
+
+digIT is the commitee responsible for managing and developing the digital
+systems of the IT programme
+
+Our services includes chalmers.it and various digital equipments in our student
+division premises. Most of our software development is hosted on our GitHub.
+
+Do you have any ideas for improvements or simply want to get in touch with us?
+Shoot us an email![0m


### PR DESCRIPTION
When running `curl https://digit.chalmers.it` the HTML of the page is printed to the console. Something fun we can do instead is to print an ANSI text representation of the page. That is what this PR does.

It's just a fun easter egg that someone might find.