### PR TITLE
Replace IRC link with Slack link

### DIFF
--- a/templates/index.ansi.html.tera
+++ b/templates/index.ansi.html.tera
@@ -22,7 +22,7 @@
                                          1
                                      011
 
-                 digit@chalmers.it | #digIT on irc.chalmers.it
+                 digit@chalmers.it | #digit on slack.chalmers.it
             Facebook/digitchalmers | Twitter/digITcth | GitHub/cthit
 
 [7m About us [27m

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -36,7 +36,7 @@
         </pre>
         </div>
         <div id="links">
-            <a href="mailto:digit@chalmers.it">digit@chalmers.it</a> | <a href="https://irc.chalmers.it">#digIT on irc.chalmers.it</a> | <a href="https://www.facebook.com/digitchalmers">Facebook</a> |  <a href="https://twitter.com/digITcth">Twitter</a> | <a href="https://github.com/cthit">GitHub</a>
+            <a href="mailto:digit@chalmers.it">digit@chalmers.it</a> | <a href="https://slack.chalmers.it">#digit on slack.chalmers.it</a> | <a href="https://www.facebook.com/digitchalmers">Facebook</a> |  <a href="https://twitter.com/digITcth">Twitter</a> | <a href="https://github.com/cthit">GitHub</a>
             <div style="text-align: center;margin-top: 5px;"><a href="/members">Members</a> | <a href="https://findit.chalmers.it">Projects</a> | <a href="https://digit.chalmers.it/wiki">Wiki</a></div>
         </div>
         <div id="about">
@@ -44,8 +44,7 @@
             <p>digIT is the commitee responsible for managing and developing the digital systems of the IT programme</p>
 
             <p>Our services includes chalmers.it and various digital equipments in our student division premises. Most of our software development is hosted on <a href="https://github.com/cthit">Github</a>.</p>
-            
-            <p>Do you have any ideas for improvements or simply want to get in touch with us? Shoot us an email!</p>            
+            <p>Do you have any ideas for improvements or simply want to get in touch with us? Shoot us an email!</p>
         </div>
     </body>
 </html>


### PR DESCRIPTION
irc.chalmers.it is a dead link, and digit only hangs out on the Slack:tm:  anyways

let's all join together and praise our corporate overlords :pray: